### PR TITLE
Update FetchCommand.php

### DIFF
--- a/src/Console/Commands/FetchCommand.php
+++ b/src/Console/Commands/FetchCommand.php
@@ -64,7 +64,7 @@ class FetchCommand extends Command {
     }
 
     protected function cleanLocaleDir($item) {
-        return str_replace($this->lang_path.'/', '', $item);
+        return basename($item);
     }
 
     protected function cleanGroupDir($item, $locale) {


### PR DESCRIPTION
Fixes an issue on Windows platform. Wrong paths separator. As result - imposible to fetch by specifying locale name

```
php artisan translation:fetch -l en
```
