### PR TITLE
Update TranslationsController.php

### DIFF
--- a/src/Controllers/TranslationsController.php
+++ b/src/Controllers/TranslationsController.php
@@ -93,7 +93,9 @@ class TranslationsController extends Controller {
     }
 
     public function postTranslate(Request $request) {
-        $text = TranslateClient::translate($request->input('origin'), $request->input('target'), $request->input('text'));
+        $text = preg_replace('/(:)(\w+)/', '--$2', $request->input('text'));
+        $text = TranslateClient::translate($request->input('origin'), $request->input('target'), $text);
+        $text = preg_replace('/(--)(\w+)/', ':$2', $text);
         $key = $request->input('key');
         return compact('key', 'text');
     }


### PR DESCRIPTION
Do not allow the google to translate special tags like `:atribute` in strings.
Ex.: en
```
The :attribute must have between :min and :max items.
```
Will be translated to: ru
```
:attribute Должны иметь между :min и :max пунктов.
```