### PR TITLE
respect the webinterface config setting

### DIFF
--- a/config/translation-db.php
+++ b/config/translation-db.php
@@ -10,7 +10,7 @@ return [
     /**
      * This setting enables or disables the web interface and its routes.
      */
-    'webinterface' => true,
+    'webinterface' => env('APP_DEBUG', false),
 
     /**
      * This is the prefix for on which URI the Translations Manager will

--- a/config/translation-db.php
+++ b/config/translation-db.php
@@ -28,12 +28,15 @@ return [
     'disable_debugbar' => true,
 
     /**
-     * - Force translations to be cached, even in Debug Mode.
-     * - And disables the collection of new keys.
      * This can be used to prevent lots of queries from
      * happening.
      */
-    'minimal' => false,
+    'cache' => !env('APP_DEBUG', false),
+
+    /**
+     * Collect new keys
+     */
+    'collect' => env('APP_DEBUG', false),
 
     /**
      * Use locales from files as a fallback option. Be aware that

--- a/src/DatabaseLoader.php
+++ b/src/DatabaseLoader.php
@@ -53,10 +53,10 @@ class DatabaseLoader implements LoaderInterface {
      */
     public function addTranslation($locale, $group, $key)
     {
-        if(!\Config::get('app.debug') || \Config::get('translation-db.minimal')) return;
+        if(!\Config::get('translation-db.collect')) return;
 
         // Extract the real key from the translation.
-        if (preg_match("/^{$group}\.(.*?)$/sm", $key, $match)) {
+        if (preg_match("/^{$group}\\.(.*?)$/sm", $key, $match)) {
             $name = $match[1];
         } else {
             throw new TranslationException('Could not extract key from translation.');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,8 +64,7 @@ class ServiceProvider extends \Illuminate\Translation\TranslationServiceProvider
 		$this->loadViewsFrom(__DIR__.'/../views', 'translation');
 		$this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'translation');
 
-		// Only in debug mode the translations interface should be available.
-		if($this->app['config']->get('app.debug') && $this->app['config']->get('translation-db.webinterface')) {
+		if($this->app['config']->get('translation-db.webinterface')) {
 			$routeConfig = [
 				'namespace' => 'Hpolthof\Translation\Controllers',
 				'prefix' => $this->app['config']->get('translation-db.route_prefix'),

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -72,7 +72,7 @@ class Translator extends \Illuminate\Translation\Translator implements Translato
 		// This will allow legacy support.
 		if(!self::isNamespaced($namespace)) {
 			// If debug is off then cache the result forever to ensure high performance.
-			if(!\Config::get('app.debug') || \Config::get('translation-db.minimal')) {
+			if(\Config::get('translation-db.cache')) {
 				$that = $this;
 				$lines = \Cache::rememberForever('__translations.'.$locale.'.'.$group, function() use ($that, $locale, $group, $namespace) {
 					return $that->loadFromDatabase($namespace, $group, $locale);


### PR DESCRIPTION
In an environment where access to /_translations is gated by the webserver itself, it's okay to show the webinterface in production. This change respects the user's config setting, and defaults the webinterface boolean to the APP_DEBUG var, if set, and false otherwise. The user of course is free to override that in their own config file.